### PR TITLE
android-headers: switch to use virtual package for android headers

### DIFF
--- a/android-headers-30/PKGBUILD
+++ b/android-headers-30/PKGBUILD
@@ -6,6 +6,8 @@ arch=('aarch64')
 url="https://github.com/Linux-on-droid/android-headers-30"
 license=('GPL2')
 depends=('make')
+provides=('android-headers')
+conflicts=('android-headers')
 source=("git+https://github.com/Linux-on-droid/android-headers-30.git")
 sha256sums=('SKIP')
 

--- a/libhybris/PKGBUILD
+++ b/libhybris/PKGBUILD
@@ -12,7 +12,7 @@ pkgdesc="A library to enable Android and Wayland compatibility"
 arch=('x86_64' 'aarch64' 'armv7h')  # Adjust as necessary
 url="https://github.com/Linux-on-droid/libhybris"
 license=('LGPL2.1')
-depends=('make' 'autoconf' 'automake' 'libtool' 'pkg-config' 'wayland' 'android-headers-30' 'wayland-protocols' 'python' 'mesa' 'libglvnd')
+depends=('make' 'autoconf' 'automake' 'libtool' 'pkg-config' 'wayland' 'android-headers' 'wayland-protocols' 'python' 'mesa' 'libglvnd')
 source=("git+https://github.com/Linux-on-droid/libhybris.git")
 sha256sums=('SKIP')  # SKIP since we're using git for source
 


### PR DESCRIPTION
- Package `android-headers-30` now provides a virtual package `android-headers`
- Package `libhybris` now depends on virtual package `android-headers` so that other version of android headers can also be used.